### PR TITLE
feat: add light theme variables

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,10 +4,18 @@
   }
   body { margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
   body.theme-dark { background:#0b0e13; color:var(--text); }
-  body:not(.theme-dark) { background:#f6f8fa; color:#0b1220; }
+  body:not(.theme-dark) {
+    --bg: #f6f8fa;
+    --panel: #ffffff;
+    --text: #0b1220;
+    --muted: #57606a;
+    --border: rgba(0,0,0,0.12);
+    background: var(--bg);
+    color: var(--text);
+  }
   
   .topbar { display:flex; justify-content:space-between; align-items:center; gap:1rem; padding:0.75rem 1rem; position:sticky; top:0; backdrop-filter:saturate(1.2) blur(6px); background:rgba(20,24,31,0.75); color:var(--text); border-bottom:1px solid rgba(255,255,255,0.06); }
-  body:not(.theme-dark) .topbar { background:rgba(255,255,255,0.85); color:#0b1220; border-bottom:1px solid rgba(0,0,0,0.05); }
+  body:not(.theme-dark) .topbar { background:rgba(255,255,255,0.85); color:var(--text); border-bottom:1px solid rgba(0,0,0,0.05); }
   .brand { font-weight:700; }
   .muted { opacity:0.7; }
   .actions { display:flex; gap:0.5rem; }


### PR DESCRIPTION
## Summary
- define light theme colors for panel, text, muted and borders when the `theme-dark` class is absent
- use `var(--text)` for top bar text color in light mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ca9a11d4832c9d95afb8e8c6116f